### PR TITLE
Add support for tracking current valid platform groups

### DIFF
--- a/v1x1-common/schema.cql
+++ b/v1x1-common/schema.cql
@@ -479,3 +479,14 @@ CREATE TABLE migrations (
 );
 
 INSERT INTO migrations (version, name, migrated_at) VALUES (10, 'i18n_module_definition, permission_module_definition, and migrations', NOW());
+
+/* Version 11 */
+CREATE TABLE channel_group_platform_group (
+    platform int,
+    channel_group_id text,
+    name text,
+    display_name text,
+    PRIMARY KEY ((platform, channel_group_id), name)
+);
+
+INSERT INTO migrations (version, name, migrated_at) VALUES (11, 'channel_group_platform_group', NOW());

--- a/v1x1-common/src/main/java/tv/v1x1/common/dao/DAOChannelGroupPlatformGroups.java
+++ b/v1x1-common/src/main/java/tv/v1x1/common/dao/DAOChannelGroupPlatformGroups.java
@@ -1,0 +1,57 @@
+package tv.v1x1.common.dao;
+
+import com.datastax.driver.mapping.Mapper;
+import com.datastax.driver.mapping.MappingManager;
+import com.datastax.driver.mapping.Result;
+import com.datastax.driver.mapping.annotations.Accessor;
+import com.datastax.driver.mapping.annotations.Query;
+import tv.v1x1.common.dto.db.ChannelGroupPlatformGroup;
+import tv.v1x1.common.dto.db.Platform;
+
+import java.util.Map;
+import java.util.stream.StreamSupport;
+
+public class DAOChannelGroupPlatformGroups {
+    private final Mapper<ChannelGroupPlatformGroup> mapper;
+    private final ChannelGroupPlatformGroupAccessor accessor;
+
+    @Accessor
+    public interface ChannelGroupPlatformGroupAccessor {
+        @Query("SELECT * FROM channel_group_platform_group WHERE platform = ? AND channel_group_id = ?")
+        Result<ChannelGroupPlatformGroup> allByChannelGroup(final Platform platform, final String channelGroupId);
+    }
+
+    public DAOChannelGroupPlatformGroups(final MappingManager mappingManager) {
+        mapper = mappingManager.mapper(ChannelGroupPlatformGroup.class);
+        accessor = mappingManager.createAccessor(ChannelGroupPlatformGroupAccessor.class);
+    }
+
+    public Iterable<ChannelGroupPlatformGroup> getAll(final Platform platform, final String channelGroupId) {
+        return accessor.allByChannelGroup(platform, channelGroupId);
+    }
+
+    public ChannelGroupPlatformGroup get(final Platform platform, final String channelGroupId, final String name) {
+        return mapper.get(platform, channelGroupId, name);
+    }
+
+    public void put(final ChannelGroupPlatformGroup channelGroupPlatformGroup) {
+        mapper.save(channelGroupPlatformGroup);
+    }
+
+    public void delete(final Platform platform, final String channelGroupId, final String name) {
+        mapper.delete(platform, channelGroupId, name);
+    }
+
+    public void putOnly(final Platform platform, final String channelGroupId, final Map<String, String> entries) {
+        StreamSupport.stream(getAll(platform, channelGroupId).spliterator(), false)
+                .filter(channelGroupPlatformGroup -> !entries.containsKey(channelGroupPlatformGroup.getName()))
+                .forEach(channelGroupPlatformGroup -> delete(platform, channelGroupId, channelGroupPlatformGroup.getName()));
+        entries.entrySet().stream().map(entry -> new ChannelGroupPlatformGroup(platform, channelGroupId, entry.getKey(), entry.getValue()))
+                .forEach(this::put);
+    }
+
+    public void deleteAll(final Platform platform, final String channelGroupId) {
+        for(final ChannelGroupPlatformGroup channelGroupPlatformGroup : getAll(platform, channelGroupId))
+            delete(channelGroupPlatformGroup.getPlatform(), channelGroupPlatformGroup.getChannelGroupId(), channelGroupPlatformGroup.getName());
+    }
+}

--- a/v1x1-common/src/main/java/tv/v1x1/common/dto/db/ChannelGroupPlatformGroup.java
+++ b/v1x1-common/src/main/java/tv/v1x1/common/dto/db/ChannelGroupPlatformGroup.java
@@ -1,0 +1,61 @@
+package tv.v1x1.common.dto.db;
+
+import com.datastax.driver.mapping.annotations.ClusteringColumn;
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+
+@Table(name = "channel_group_platform_group")
+public class ChannelGroupPlatformGroup {
+    @PartitionKey
+    private Platform platform;
+    @PartitionKey(1)
+    @Column(name = "channel_group_id")
+    private String channelGroupId;
+    @ClusteringColumn
+    private String name;
+    @Column(name = "display_name")
+    private String displayName;
+
+    public ChannelGroupPlatformGroup() {
+    }
+
+    public ChannelGroupPlatformGroup(final Platform platform, final String channelGroupId, final String name, final String displayName) {
+        this.platform = platform;
+        this.channelGroupId = channelGroupId;
+        this.name = name;
+        this.displayName = displayName;
+    }
+
+    public Platform getPlatform() {
+        return platform;
+    }
+
+    public void setPlatform(final Platform platform) {
+        this.platform = platform;
+    }
+
+    public String getChannelGroupId() {
+        return channelGroupId;
+    }
+
+    public void setChannelGroupId(final String channelGroupId) {
+        this.channelGroupId = channelGroupId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(final String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/v1x1-common/src/main/java/tv/v1x1/common/services/persistence/DAOManager.java
+++ b/v1x1-common/src/main/java/tv/v1x1/common/services/persistence/DAOManager.java
@@ -6,6 +6,7 @@ import com.google.inject.Singleton;
 import org.redisson.api.RedissonClient;
 import tv.v1x1.common.dao.DAOChannelConfiguration;
 import tv.v1x1.common.dao.DAOChannelGroupConfiguration;
+import tv.v1x1.common.dao.DAOChannelGroupPlatformGroups;
 import tv.v1x1.common.dao.DAOConfigurationDefinition;
 import tv.v1x1.common.dao.DAOGlobalConfiguration;
 import tv.v1x1.common.dao.DAOGlobalUser;
@@ -42,6 +43,7 @@ public class DAOManager {
     private final DAOJoinedTwitchChannel daoJoinedTwitchChannel;
     private final DAOI18nDefinition daoI18nDefinition;
     private final DAOPermissionDefinition daoPermissionDefinition;
+    private final DAOChannelGroupPlatformGroups daoChannelGroupPlatformGroups;
 
     @Inject
     public DAOManager(final RedissonClient redissonClient, final MappingManager mappingManager, final DisplayNameService displayNameService) {
@@ -60,6 +62,7 @@ public class DAOManager {
         daoJoinedTwitchChannel = new DAOJoinedTwitchChannel(mappingManager);
         daoI18nDefinition = new DAOI18nDefinition(mappingManager);
         daoPermissionDefinition = new DAOPermissionDefinition(mappingManager);
+        daoChannelGroupPlatformGroups = new DAOChannelGroupPlatformGroups(mappingManager);
     }
 
     public DAOTenant getDaoTenant() {
@@ -120,5 +123,9 @@ public class DAOManager {
 
     public DAOPermissionDefinition getDaoPermissionDefinition() {
         return daoPermissionDefinition;
+    }
+
+    public DAOChannelGroupPlatformGroups getDaoChannelGroupPlatformGroups() {
+        return daoChannelGroupPlatformGroups;
     }
 }

--- a/v1x1-modules/v1x1-modules-core/v1x1-modules-core-api/src/main/java/tv/v1x1/modules/core/api/api/rest/ChannelGroupPlatformGroup.java
+++ b/v1x1-modules/v1x1-modules-core/v1x1-modules-core-api/src/main/java/tv/v1x1/modules/core/api/api/rest/ChannelGroupPlatformGroup.java
@@ -1,0 +1,34 @@
+package tv.v1x1.modules.core.api.api.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ChannelGroupPlatformGroup {
+    @JsonProperty
+    private String name;
+    @JsonProperty("display_name")
+    private String displayName;
+
+    public ChannelGroupPlatformGroup() {
+    }
+
+    public ChannelGroupPlatformGroup(final String name, final String displayName) {
+        this.name = name;
+        this.displayName = displayName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(final String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/v1x1-modules/v1x1-modules-core/v1x1-modules-core-api/src/main/java/tv/v1x1/modules/core/api/resources/tenant/ChannelsResource.java
+++ b/v1x1-modules/v1x1-modules-core/v1x1-modules-core-api/src/main/java/tv/v1x1/modules/core/api/resources/tenant/ChannelsResource.java
@@ -1,6 +1,7 @@
 package tv.v1x1.modules.core.api.resources.tenant;
 
 import com.google.inject.Inject;
+import tv.v1x1.common.dao.DAOChannelGroupPlatformGroups;
 import tv.v1x1.common.dao.DAOJoinedTwitchChannel;
 import tv.v1x1.common.dao.DAOTenant;
 import tv.v1x1.common.dto.core.Tenant;
@@ -13,6 +14,7 @@ import tv.v1x1.modules.core.api.api.rest.ApiList;
 import tv.v1x1.modules.core.api.api.rest.ApiPrimitive;
 import tv.v1x1.modules.core.api.api.rest.Channel;
 import tv.v1x1.modules.core.api.api.rest.ChannelGroup;
+import tv.v1x1.modules.core.api.api.rest.ChannelGroupPlatformGroup;
 import tv.v1x1.modules.core.api.auth.Authorizer;
 
 import javax.ws.rs.ClientErrorException;
@@ -32,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * @author Cobi
@@ -52,6 +55,7 @@ import java.util.stream.Collectors;
 public class ChannelsResource {
     private final DAOTenant daoTenant;
     private final DAOJoinedTwitchChannel daoJoinedTwitchChannel;
+    private final DAOChannelGroupPlatformGroups daoChannelGroupPlatformGroups;
     private final Authorizer authorizer;
     private final ApiModule module;
 
@@ -59,6 +63,7 @@ public class ChannelsResource {
     public ChannelsResource(final DAOManager daoManager, final Authorizer authorizer, final ApiModule module) {
         this.daoTenant = daoManager.getDaoTenant();
         this.daoJoinedTwitchChannel = daoManager.getDaoJoinedTwitchChannel();
+        this.daoChannelGroupPlatformGroups = daoManager.getDaoChannelGroupPlatformGroups();
         this.authorizer = authorizer;
         this.module = module;
     }
@@ -127,6 +132,21 @@ public class ChannelsResource {
     public Response unlinkChannel(@PathParam("tenant_id") final String tenantId, @PathParam("platform") final String platform,
                                   @PathParam("channel_id") final String channelId) {
         return null; //TODO
+    }
+
+    @Path("/{platform}/{channel_group_id}/platform-groups")
+    @GET
+    public ApiList<ChannelGroupPlatformGroup> getPlatformGroups(@HeaderParam("Authorization") final String authorization,
+                                                                @PathParam("tenant_id") final String tenantId,
+                                                                @PathParam("platform") final String platformStr,
+                                                                @PathParam("channel_group_id") final String channelGroupId) {
+        final Tenant tenant = getTenant(tenantId);
+        authorizer.tenantAuthorization(tenant.getId().getValue(), authorization).ensurePermission("api.tenants.read");
+        final Platform platform = getDtoPlatform(platformStr);
+        final ChannelGroup channelGroup = getDtoChannelGroup(tenant, platform, channelGroupId);
+        return new ApiList<>(StreamSupport.stream(daoChannelGroupPlatformGroups.getAll(platform, channelGroup.getId()).spliterator(), false)
+                .map(channelGroupPlatformGroup -> new ChannelGroupPlatformGroup(channelGroupPlatformGroup.getName(), channelGroupPlatformGroup.getDisplayName()))
+                .collect(Collectors.toList()));
     }
 
     @Path("/{platform}/{channel_group_id}/state")

--- a/v1x1-modules/v1x1-modules-core/v1x1-modules-core-discord/src/main/java/tv/v1x1/modules/core/discord/DiscordModule.java
+++ b/v1x1-modules/v1x1-modules-core/v1x1-modules-core-discord/src/main/java/tv/v1x1/modules/core/discord/DiscordModule.java
@@ -218,8 +218,8 @@ public class DiscordModule extends ServiceModule<DiscordGlobalConfiguration, Dis
         scheduledExecutorService = Executors.newScheduledThreadPool(100);
         identifyShortLimiter = new GlobalRateLimiter(getCuratorFramework(), scheduledExecutorService, "discord/identify/short", 1, 8);
         identifyDailyLimiter = new GlobalRateLimiter(getCuratorFramework(), scheduledExecutorService, "discord/identify/daily", 900, 86400);
-        lastSeen = getRedisson().getMapCache("Modules|Core|Discord|lastSeen", ByteArrayCodec.INSTANCE);
-        sessionIds = getRedisson().getMapCache("Modules|Core|Discord|sessionIds", ByteArrayCodec.INSTANCE);
+        lastSeen = getRedisson().getMapCache("Modules|Core|Discord|lastSeen|v2", ByteArrayCodec.INSTANCE);
+        sessionIds = getRedisson().getMapCache("Modules|Core|Discord|sessionIds|v2", ByteArrayCodec.INSTANCE);
         roles = getRedisson().getMapCache("Modules|Core|Discord|roles", ByteArrayCodec.INSTANCE);
         voiceStates = getRedisson().getMapCache("Modules|Core|Discord|voiceStates", ByteArrayCodec.INSTANCE);
         eventRouter = getMessageQueueManager().forName(getMainQueueForModule(new Module("event_router")));

--- a/v1x1-modules/v1x1-modules-core/v1x1-modules-core-tmi/src/main/java/tv/v1x1/modules/core/tmi/TmiModule.java
+++ b/v1x1-modules/v1x1-modules-core/v1x1-modules-core-tmi/src/main/java/tv/v1x1/modules/core/tmi/TmiModule.java
@@ -5,6 +5,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +17,7 @@ import tv.v1x1.common.dto.core.Tenant;
 import tv.v1x1.common.dto.core.UUID;
 import tv.v1x1.common.dto.db.JoinedTwitchChannel;
 import tv.v1x1.common.dto.db.Platform;
+import tv.v1x1.common.dto.irc.MessageTaggedIrcStanza;
 import tv.v1x1.common.dto.messages.events.SchedulerNotifyEvent;
 import tv.v1x1.common.modules.ServiceModule;
 import tv.v1x1.common.rpc.client.SchedulerServiceClient;
@@ -298,6 +300,21 @@ public class TmiModule extends ServiceModule<TmiGlobalConfiguration, TmiUserConf
             if (bots.containsKey(channelId))
                 return;
             final Tenant tenant = getTenant(channelId);
+            LOG.debug("Setting ChannelGroupPlatformGroups for {}", channel.getDisplayName());
+            getDaoManager().getDaoChannelGroupPlatformGroups().putOnly(Platform.TWITCH, channelId, ImmutableMap.<String, String>builder()
+                    .put("_DEFAULT_", "Everyone")
+                    .put(MessageTaggedIrcStanza.Badge.ADMIN.name(), "Twitch Admin")
+                    .put(MessageTaggedIrcStanza.Badge.BITS.name(), "Bits")
+                    .put(MessageTaggedIrcStanza.Badge.BROADCASTER.name(), "Broadcaster")
+                    .put(MessageTaggedIrcStanza.Badge.GLOBAL_MOD.name(), "Global Mod")
+                    .put(MessageTaggedIrcStanza.Badge.MODERATOR.name(), "Channel Moderator")
+                    .put(MessageTaggedIrcStanza.Badge.PREMIUM.name(), "Twitch Prime")
+                    .put(MessageTaggedIrcStanza.Badge.STAFF.name(), "Twitch Staff")
+                    .put(MessageTaggedIrcStanza.Badge.SUBSCRIBER.name(), "Subscriber")
+                    .put(MessageTaggedIrcStanza.Badge.TURBO.name(), "Twitch Turbo")
+                    .put(MessageTaggedIrcStanza.Badge.TWITCHCON2017.name(), "TwitchCon17 Attendee")
+                    .build()
+            );
             LOG.debug("Getting tenant configuration for {}/{}", channel.getDisplayName(), tenant);
             final TmiUserConfiguration tenantConfiguration = getConfiguration(tenant.getChannel(Platform.TWITCH, channelId, channelId + ":main").get());
             final String oauthToken;


### PR DESCRIPTION
```
This commit adds support for tracking current valid
platform groups in the channel_group_platform_group
table in cassandra.

This commit also adds an API endpoint to retrieve
these valid platform groups, restricted by the
api.tenants.read permission.

Finally, this commit also adds hooks into the tmi
and discord modules to manage the valid platform
groups.
```